### PR TITLE
Reintroduce rootURL config

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,22 +4,22 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>5apps Storage</title>
-    <link href="favicon.ico" rel="shortcut icon" type="image/x-icon">
+    <link href="{{rootURL}}favicon.ico" rel="shortcut icon" type="image/x-icon">
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {{content-for "head"}}
 
-    <link integrity="" rel="stylesheet" href="/assets/vendor.css">
-    <link integrity="" rel="stylesheet" href="/assets/storage-frontend.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/storage-frontend.css">
 
     {{content-for "head-footer"}}
   </head>
   <body class="storage">
     {{content-for "body"}}
 
-    <script src="/assets/vendor.js"></script>
-    <script src="/assets/storage-frontend.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/storage-frontend.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/app/router.js
+++ b/app/router.js
@@ -3,6 +3,7 @@ import config from './config/environment';
 
 export default class Router extends EmberRouter {
   location = config.locationType;
+  rootURL = config.rootURL;
 }
 
 Router.map(function() {

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -8,7 +8,7 @@ export default SessionService.extend({
 
   authenticateWithImplicitGrant() {
     const clientId = 'storage-frontend';
-    const redirectURI = `${window.location.origin}/callback`;
+    const redirectURI = `${window.location.origin}${config.rootURL}callback`;
     const responseType = 'token';
     const scope = 'storage-frontend';
 

--- a/app/templates/components/topbar.hbs
+++ b/app/templates/components/topbar.hbs
@@ -1,6 +1,6 @@
 <header class="topbar">
   <h1>
-    <img src="/assets/brand/icon-gradient-blue.svg" alt="" role="presentation">
+    <img src="{{this.rootURL}}assets/brand/icon-gradient-blue.svg" alt="" role="presentation">
     <span class="primary"><a href={{this.frontpageUrl}}>5apps</a></span>
     <span class="secondary">Storage</span>
   </h1>

--- a/config/environment.js
+++ b/config/environment.js
@@ -7,6 +7,7 @@ module.exports = function(environment) {
   let ENV = {
     modulePrefix: 'storage-frontend',
     environment,
+    rootURL: '/',
     locationType: 'auto',
     EmberENV: {
       FEATURES: {

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,9 +10,9 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="/assets/vendor.css">
-    <link rel="stylesheet" href="/assets/storage-frontend.css">
-    <link rel="stylesheet" href="/assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/storage-frontend.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
@@ -22,10 +22,10 @@
     {{content-for "test-body"}}
 
     <script src="/testem.js" integrity=""></script>
-    <script src="/assets/vendor.js"></script>
-    <script src="/assets/test-support.js"></script>
-    <script src="/assets/storage-frontend.js"></script>
-    <script src="/assets/tests.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/storage-frontend.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}


### PR DESCRIPTION
This adds back the `rootURL` config that was removed in #26, but sets it to `'/'`.

The rootURL config is a core Ember concept and some Ember addons might rely on it being present.

Also, I think when running automated Ember upgrades, it re-adds them to files like `index.html` which would lead to unneccesary manual changes.