### PR TITLE
Add release-drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,19 @@
+categories:
+  - title: 'Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'design'
+  - title: 'Bug Fixes'
+    labels:
+      - 'bug'
+  - title: 'Maintenance'
+    labels:
+      - 'chore'
+      - 'dev environment'
+exclude-labels:
+  - 'skip changelog'
+template: |
+  ## Changes
+
+  $CHANGES


### PR DESCRIPTION
Let's use teh drafter to make it easier for us to see deployed changes. (Release notes are part of Gitea migrations as well.)