### PR TITLE
Reduce topbar links to icons only

### DIFF
--- a/app/components/topbar/template.hbs
+++ b/app/components/topbar/template.hbs
@@ -11,9 +11,12 @@
           <li>
             <BasicDropdown @horizontalPosition="right" as |dd|>
               <dd.Trigger>
-                <IconLifeBuoy /> <span class="help">Help</span>
+                <IconLifeBuoy />
               </dd.Trigger>
               <dd.Content class="slide-fade">
+                <div class="header">
+                  <h4>Help</h4>
+                </div>
                 <ul>
                   <li>
                     <a href="https://5apps.tenderapp.com/kb/storage"
@@ -46,9 +49,15 @@
           <li class="account">
             <BasicDropdown @horizontalPosition="right" as |dd|>
               <dd.Trigger>
-                <IconUser /> <span class="username">{{this.currentUser.user.username}}</span><span class="hostname">@{{this.currentUser.user.storageHost}}</span>
+                <IconUser />
               </dd.Trigger>
               <dd.Content class="slide-fade">
+                <div class="header">
+                  <h4 class="small">User address</h4>
+                  <p>
+                    <span class="username">{{this.currentUser.user.username}}</span><span class="hostname">@{{this.currentUser.user.storageHost}}</span>
+                  </p>
+                </div>
                 <ul>
                   <li>
                     <a href="https://{{this.baseDomain}}/account/settings"

--- a/app/styles/components/_ember-basic-dropdown.scss
+++ b/app/styles/components/_ember-basic-dropdown.scss
@@ -1,9 +1,25 @@
 .ember-basic-dropdown-content {
-  min-width: 160px;
+  margin-top: -0.3rem;
+  min-width: 200px;
   background-color: #fff;
   border: 1px solid $lightBodyContentBoxBorder;
   border-radius: 4px;
   box-shadow: 0 6px 12px rgba(0,0,0,.175);
+
+  .header {
+    padding: 1rem;
+    border-bottom: 1px solid $lightBodyContentBoxBorder;
+
+    h4 {
+      margin: 0;
+
+      &.small {
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        margin: 0 0 0.5em 0;
+      }
+    }
+  }
 
   ul {
     li {

--- a/app/styles/components/_topbar.scss
+++ b/app/styles/components/_topbar.scss
@@ -34,6 +34,7 @@ header.topbar {
   nav {
     display: block;
     float: right;
+    margin-right: 0.4rem;
     width: auto;
     font-size: 1rem;
 
@@ -43,14 +44,14 @@ header.topbar {
 
         a, .ember-basic-dropdown-trigger {
           display: inline-block;
-          padding: 0 1rem;
+          padding: 0 0.6rem;
           text-decoration: none;
           color: $greyTextOnDarkGrey;
           transition: color 0.1s linear;
           cursor: pointer;
 
           svg {
-            height: 1.2rem;
+            height: 1.4rem;
             width: auto;
             vertical-align: middle;
             margin-top: -0.2rem;
@@ -75,22 +76,6 @@ header.topbar {
 
       span.secondary {
         color: #fff;
-      }
-    }
-
-    nav {
-      ul {
-        li {
-          &:last-of-type a {
-            padding-right: 1rem;
-          }
-
-          &.account {
-            .hostname {
-              display: none;
-            }
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
This gives us more space on mobile, and also the user address can be shown in full and explained as such.

Also pull up the dropdown content a bit, so it's closer to the trigger, and looks a bit better.

![Screenshot from 2020-02-08 14-23-11](https://user-images.githubusercontent.com/842/74090937-b1a67680-4a7f-11ea-96a2-55aadaa68dbf.png)
