### PR TITLE
Fix logout

### DIFF
--- a/app/components/topbar/component.js
+++ b/app/components/topbar/component.js
@@ -13,7 +13,7 @@ export default class TopbarComponent extends Component {
 
   @action
   logout () {
-    this.set('session.userTriggeredSignout', true);
+    this.session.set('userTriggeredSignout', true);
     this.session.invalidate();
   }
 


### PR DESCRIPTION
The new Glimmer components do not have a `set` method anymore, so it needs to be called directly on the session service.