### PR TITLE
Remove login/signup links from topbar

### DIFF
--- a/app/components/topbar/template.hbs
+++ b/app/components/topbar/template.hbs
@@ -75,15 +75,6 @@
             </BasicDropdown>
           </li>
         {{/if}}
-      {{else}}
-        <li class="login">
-          <LinkTo @route="login">
-            <IconLogIn /> log in
-          </LinkTo>
-        </li>
-        <li class="signup">
-          <a href="https://{{this.baseDomain}}/users/sign_up?site=storage">sign up</a>
-        </li>
       {{/if}}
     </ul>
   </nav>


### PR DESCRIPTION
We always redirect to the login automatically, and this way they don't flash up for a second when re-authing.