### PR TITLE
Remove Sentry API token from .env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,3 @@ BASE_DOMAIN='example.com'
 API_HOST='https://api.example.com'
 # Sentry DSN for sending exceptions
 SENTRY_DSN='123456abcdef'
-# Sentry API token for creating releases
-# Create it at https://sentry.io/api/ with scope "project:releases".
-SENTRY_API_TOKEN='123456abcdef'


### PR DESCRIPTION
Sentry releases are not created from the repo anymore.